### PR TITLE
Pod html doc 20210803

### DIFF
--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -2,9 +2,10 @@ package Pod::Html;
 use strict;
 use Exporter 'import';
 
-our $VERSION = 1.31;
+our $VERSION = 1.32;
 $VERSION = eval $VERSION;
-our @EXPORT = qw(pod2html);
+our @EXPORT = qw(pod2html htmlify);
+our @EXPORT_OK = qw(anchorify relativize_url);
 
 use Config;
 use Cwd;
@@ -15,9 +16,7 @@ use Pod::Simple::Search;
 use Pod::Simple::SimpleTree ();
 use Pod::Html::Util qw(
     html_escape
-    htmlify
     parse_command_line
-    relativize_url
     trim_leading_whitespace
     unixify
     usage
@@ -193,6 +192,28 @@ Specify the title of the resulting HTML file.
 Display progress messages.  By default, they won't be displayed.
 
 =back
+
+=head2 Auxiliary Functions
+
+Prior to perl-5.36, the following three functions were exported by F<Pod::Html>, either by default or on request:
+
+=over 4
+
+=item * C<htmlify()> (by default)
+
+=item * C<anchorify()> (upon request)
+
+=item * C<relativize_url()> (upon request)
+
+=back
+
+The definition and documentation of these functions have been moved to
+F<Pod::Html::Util>, viewable via C<perldoc Pod::Html::Util>.
+
+In perl-5.36, these functions will be importable from either F<Pod::Html> or
+F<Pod::Html::Util>.  However, beginning with perl-5.38 they will only be
+importable, upon request, from F<Pod::Html::Util>.  Please modify your code as
+needed.
 
 =head1 ENVIRONMENT
 
@@ -585,6 +606,11 @@ sub write_file {
     close $fhout or die "Failed to close $globals->{Htmlfile}: $!";
     chmod 0644, $globals->{Htmlfile} unless $globals->{Htmlfile} eq '-';
 }
+
+sub htmlify { Pod::Html::Util::htmlify() }
+sub anchorify { Pod::Html::Util::anchorify() }
+sub relativize_url { Pod::Html::Util::relativize_url() }
+
 
 package Pod::Simple::XHTML::LocalPodLinks;
 use strict;

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -30,6 +30,15 @@ Pod::Html::Util - helper functions for Pod-Html
 
 =head1 SUBROUTINES
 
+B<Note:> While these functions are importable on request from
+F<Pod::Html::Util>, they are specifically intended for use within (a) the
+F<Pod-Html> distribution (modules and test programs) shipped as part of the
+Perl 5 core and (b) other parts of the core such as the F<installhtml>
+program.  These functions may be modified or relocated within the core
+distribution -- or removed entirely therefrom -- as the core's needs evolve.
+Hence, you should not rely on these functions in situations other than those
+just described.
+
 =head2 C<parse_command_line()>
 
 TK

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -39,11 +39,10 @@ distribution -- or removed entirely therefrom -- as the core's needs evolve.
 Hence, you should not rely on these functions in situations other than those
 just described.
 
-=head2 C<parse_command_line()>
-
-TK
-
 =cut
+
+# parse_command_line will be moved back to lib/Pod/Html.pm in a subsequent
+# p.r. and will be documented then and there
 
 sub parse_command_line {
     my $globals = shift;
@@ -107,7 +106,7 @@ sub parse_command_line {
 
 =head2 C<usage()>
 
-TK
+Display customary Pod::Html usage information.
 
 =cut
 
@@ -158,7 +157,8 @@ END_OF_USAGE
 
 =head2 C<unixify()>
 
-TK
+Ensure that F<Pod::Html>'s internals and tests handle paths consistently
+across Unix, Windows and VMS.
 
 =cut
 

--- a/ext/Pod-Html/lib/Pod/Html/Util.pm
+++ b/ext/Pod-Html/lib/Pod/Html/Util.pm
@@ -2,7 +2,7 @@ package Pod::Html::Util;
 use strict;
 require Exporter;
 
-our $VERSION = 1.31; # Please keep in synch with lib/Pod/Html.pm
+our $VERSION = 1.32; # Please keep in synch with lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(

--- a/ext/Pod-Html/t/anchorify.t
+++ b/ext/Pod-Html/t/anchorify.t
@@ -2,7 +2,7 @@
 
 use strict;
 use Pod::Html::Util qw( anchorify );
-use Test::More tests => 1;
+use Test::More tests => 4;
 
 my @filedata;
 {
@@ -42,6 +42,28 @@ is_deeply(
     \%expected,
     "Got expected POD heads"
 );
+
+my ($revision,$version,$subversion) = split /\./, sprintf("%vd",$^V);
+SKIP: {
+    skip "Needed only during 5.36", 3
+        unless ($version == 35 or $version == 36);
+    require Pod::Html;
+    {
+        local $@;
+        eval { Pod::Html::anchorify(); };
+        ok( ! $@, "Can import anchorify from Pod::Html in 5.36" );
+    }
+    {
+        local $@;
+        eval { Pod::Html::htmlify(); };
+        ok( ! $@, "Can import htmlify from Pod::Html in 5.36" );
+    }
+    {
+        local $@;
+        eval { Pod::Html::relativize_url(); };
+        ok( ! $@, "Can import relativize_url from Pod::Html in 5.36" );
+    }
+}
 
 __DATA__
 =head1 NAME

--- a/ext/Pod-Html/t/lib/Testing.pm
+++ b/ext/Pod-Html/t/lib/Testing.pm
@@ -2,7 +2,7 @@ package Testing;
 use 5.10.0;
 use warnings;
 require Exporter;
-our $VERSION = 1.31; # Let's keep this same as lib/Pod/Html.pm
+our $VERSION = 1.32; # Let's keep this same as lib/Pod/Html.pm
 $VERSION = eval $VERSION;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(

--- a/pod/perldeprecation.pod
+++ b/pod/perldeprecation.pod
@@ -14,6 +14,15 @@ features are available.
 The deprecated features will be grouped by the version of Perl in
 which they will be removed.
 
+=head2 Perl 5.38
+
+=head3 Pod::Html utility functions
+
+The definition and documentation of three utility functions previously
+importable from L<Pod::Html> were moved to new package L<Pod::Html::Util> in
+Perl 5.36.  While they remain importable from L<Pod::Html> in Perl 5.36, as of
+Perl 5.38 they will only be importable, on request, from L<Pod::Html::Util>.
+
 =head2 Perl 5.34
 
 There are no deprecations or fatalizations scheduled for Perl 5.34.


### PR DESCRIPTION
To avoid compatibility problems, for the duration of perl-5.36 we'll allow 3 utility subroutines to continue to be importable from Pod::Html.  In perl-5.37 and later, those will need to be imported from Pod::Html::Util.